### PR TITLE
Adding reset and pause/resume functionality to joy

### DIFF
--- a/include/fcu_common/joy.h
+++ b/include/fcu_common/joy.h
@@ -26,6 +26,7 @@
 #include <sensor_msgs/Joy.h>
 #include <fcu_common/Command.h>
 #include <fcu_common/ExtendedCommand.h>
+#include "gazebo_msgs/ModelState.h"
 
 struct Axes {
   int roll;
@@ -90,6 +91,8 @@ class Joy {
 
   Max max_;
   Buttons buttons_;
+  geometry_msgs::Pose reset_pose_;
+  geometry_msgs::Twist reset_twist_;
 
   double current_yaw_vel_;
   double v_yaw_step_;

--- a/include/fcu_common/joy.h
+++ b/include/fcu_common/joy.h
@@ -78,7 +78,6 @@ class Joy {
   std::string autopilot_command_topic_;
 
   std::string mav_name_;
-  std::string world_name_;
 
   Axes axes_;
 

--- a/include/fcu_common/joy.h
+++ b/include/fcu_common/joy.h
@@ -59,6 +59,8 @@ struct Button{
 struct Buttons {
   Button fly;
   Button mode;
+  Button reset;
+  Button pause;
 };
 
 class Joy {
@@ -74,6 +76,9 @@ class Joy {
   std::string namespace_;
   std::string command_topic_;
   std::string autopilot_command_topic_;
+
+  std::string mav_name_;
+  std::string world_name_;
 
   Axes axes_;
 
@@ -92,6 +97,9 @@ class Joy {
   double mass_;
 
   void StopMav();
+  void ResetMav();
+  void PauseSimulation();
+  void ResumeSimulation();
 
   void JoyCallback(const sensor_msgs::JoyConstPtr& msg);
   void APCommandCallback(const fcu_common::CommandConstPtr& msg);

--- a/src/joy.cpp
+++ b/src/joy.cpp
@@ -36,7 +36,6 @@ Joy::Joy() {
 
   // Defaults -- should be set/overriden by calling launch file
   pnh.param<std::string>("mav_name", mav_name_, "shredder");
-  pnh.param<std::string>("world_name", world_name_, "empty_world");
 
   // Default to Spektrum Transmitter on Interlink
   pnh.param<int>("x_axis", axes_.roll, 1);
@@ -101,6 +100,7 @@ void Joy::StopMav() {
 /* Resets the mav back to origin */
 void Joy::ResetMav() 
 {
+	ROS_INFO("Mav position reset.");
 	ros::NodeHandle n;
     geometry_msgs::Pose start_pose;
 	start_pose.position.x = 0.0;
@@ -121,7 +121,7 @@ void Joy::ResetMav()
 
     gazebo_msgs::ModelState modelstate;
 	modelstate.model_name = (std::string) mav_name_;
-	modelstate.reference_frame = (std::string) world_name_;
+	modelstate.reference_frame = (std::string) "world";
 	modelstate.pose = start_pose;
 	modelstate.twist = start_twist;
 
@@ -134,6 +134,7 @@ void Joy::ResetMav()
 // Pauses the gazebo physics and time
 void Joy::PauseSimulation()
 {
+	ROS_INFO("Simulation paused.");
 	ros::NodeHandle n;
 
 	ros::ServiceClient client = n.serviceClient<std_srvs::Empty>("/gazebo/pause_physics");
@@ -144,6 +145,7 @@ void Joy::PauseSimulation()
 // Resumes the gazebo physics and time
 void Joy::ResumeSimulation()
 {
+	ROS_INFO("Simulation resumed.");
 	ros::NodeHandle n;
 
 	ros::ServiceClient client = n.serviceClient<std_srvs::Empty>("/gazebo/unpause_physics");

--- a/src/joy.cpp
+++ b/src/joy.cpp
@@ -20,9 +20,6 @@
 
 
 #include "fcu_common/joy.h"
-#include "geometry_msgs/Pose.h"
-#include "geometry_msgs/Twist.h"
-#include "gazebo_msgs/ModelState.h"
 #include "gazebo_msgs/SetModelState.h"
 #include "std_srvs/Empty.h"
 
@@ -63,6 +60,20 @@ Joy::Joy() {
   pnh.param<double>("max_roll_angle", max_.roll, 45.0*M_PI/180.0);
   pnh.param<double>("max_pitch_angle", max_.pitch, 45.0*M_PI/180.0);
 
+  pnh.param<double>("reset_pos_x", reset_pose_.position.x, 0.0); 
+  pnh.param<double>("reset_pos_y", reset_pose_.position.y, 0.0); 
+  pnh.param<double>("reset_pos_z", reset_pose_.position.z, 0.0); 
+  pnh.param<double>("reset_orient_x", reset_pose_.orientation.x, 0.0); 
+  pnh.param<double>("reset_orient_x", reset_pose_.orientation.y, 0.0); 
+  pnh.param<double>("reset_orient_x", reset_pose_.orientation.z, 0.0); 
+  pnh.param<double>("reset_orient_x", reset_pose_.orientation.w, 0.0); 
+  pnh.param<double>("reset_linear_twist_x", reset_twist_.linear.x, 0.0); 
+  pnh.param<double>("reset_linear_twist_y", reset_twist_.linear.y, 0.0); 
+  pnh.param<double>("reset_linear_twist_z", reset_twist_.linear.z, 0.0); 
+  pnh.param<double>("reset_angular_twist_x", reset_twist_.angular.x, 0.0); 
+  pnh.param<double>("reset_angular_twist_x", reset_twist_.angular.y, 0.0); 
+  pnh.param<double>("reset_angular_twist_x", reset_twist_.angular.z, 0.0); 
+
   // Sets which buttons are tied to which commands
   pnh.param<int>("button_takeoff_", buttons_.fly.index, 0);
   pnh.param<int>("button_mode_", buttons_.mode.index, 1);
@@ -102,31 +113,15 @@ void Joy::ResetMav()
 {
 	ROS_INFO("Mav position reset.");
 	ros::NodeHandle n;
-    geometry_msgs::Pose start_pose;
-	start_pose.position.x = 0.0;
-	start_pose.position.y = 0.0;
-	start_pose.position.z = 0.1;
-	start_pose.orientation.x = 0.0;
-	start_pose.orientation.y = 0.0;
-	start_pose.orientation.z = 0.0;
-	start_pose.orientation.w = 0.0;
 
-	geometry_msgs::Twist start_twist;
-	start_twist.linear.x = 0.0;
-	start_twist.linear.y = 0.0;
-	start_twist.linear.z = 0.0;
-	start_twist.angular.x = 0.0;
-	start_twist.angular.y = 0.0;
-	start_twist.angular.z = 0.0;
-
-    gazebo_msgs::ModelState modelstate;
+	gazebo_msgs::ModelState modelstate;
 	modelstate.model_name = (std::string) mav_name_;
 	modelstate.reference_frame = (std::string) "world";
-	modelstate.pose = start_pose;
-	modelstate.twist = start_twist;
+	modelstate.pose = reset_pose_;
+	modelstate.twist = reset_twist_;
 
-    ros::ServiceClient client = n.serviceClient<gazebo_msgs::SetModelState>("/gazebo/set_model_state");
-    gazebo_msgs::SetModelState setmodelstate;
+	ros::ServiceClient client = n.serviceClient<gazebo_msgs::SetModelState>("/gazebo/set_model_state");
+	gazebo_msgs::SetModelState setmodelstate;
 	setmodelstate.request.model_state = modelstate;
 	client.call(setmodelstate);
 }
@@ -155,7 +150,7 @@ void Joy::ResumeSimulation()
 
 void Joy::APCommandCallback(const fcu_common::CommandConstPtr &msg)
 {
-    autopilot_command_ = *msg;
+	autopilot_command_ = *msg;
 }
 
 void Joy::JoyCallback(const sensor_msgs::JoyConstPtr& msg) {

--- a/src/joy.cpp
+++ b/src/joy.cpp
@@ -243,7 +243,7 @@ void Joy::JoyCallback(const sensor_msgs::JoyConstPtr& msg) {
     mode = (mode+1)%4;
     if(mode == 0)
     {
-      ROS_INFO("Rate Mode - change test!");
+      ROS_INFO("Rate Mode");
       extended_command_msg_.mode = fcu_common::ExtendedCommand::MODE_ROLLRATE_PITCHRATE_YAWRATE_THROTTLE;
     }
     else if(mode == 1)


### PR DESCRIPTION
I added functions to reset the mav to the origin using the start button (xbox button 9) and to pause/resume the simulation using the back button (xbox button 8).
