### PR TITLE
Revert "Added header to State message"

### DIFF
--- a/msg/State.msg
+++ b/msg/State.msg
@@ -1,7 +1,6 @@
-# Vehicle state 'x_hat' output from the estimator or from simulator
+# Vehicle state 'x_hat' output from the estimator or from simulator 
 
 # @warning roll, pitch and yaw have always to be valid, the quaternion is optional
-Header header
 float32[3] position	# north, east, down (m)
 float32 Va		# Airspeed (m/s)
 float32 alpha		# Angle of attack (rad)


### PR DESCRIPTION
Reverts byu-magicc/fcu_common#15

For some reason, the added header in the fcu_common/State message is causing problems in some ros_plane nodes. I would still like to include the header, but need to do more testing to see how to get around it with the ros_plane nodes.